### PR TITLE
Pagination for exercises

### DIFF
--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -1,0 +1,1 @@
+import React from 'react';

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -1,7 +1,17 @@
 import React from 'react';
 
 const AllExercises = (props) => {
-  return (  );
+  return ( 
+    <div className="all-exercise">
+    {props.exercises ? (props.exercises.map((exercise, index) => {
+      return <div key={index}>
+        <p onClick={() =>
+           props.getExercise(exercise.id)}>{exercise.exercise_name}</p>
+        <button>Add</button>
+      </div>
+    })) : null}
+  </div>
+    );
 }
  
 export default AllExercises;

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -1,21 +1,46 @@
-import React from 'react';
+import React from "react";
 
-const AllExercises = (props) => {
-  const muscles = [ 'Neck', 
-    'Lats', "Middle Back", 'Lower Back', 'Shoulders',
-     'Chest', 'Forearms', 'Hamstrings',
-    'Calves', 'Biceps', 'Triceps', 'Traps', 'Abdominals',
-    'Glutes', 'Quadriceps', "Adductors", "Abductors"];
+const AllExercises = props => {
+  const muscles = [
+    "Neck",
+    "Lats",
+    "Middle Back",
+    "Lower Back",
+    "Shoulders",
+    "Chest",
+    "Forearms",
+    "Hamstrings",
+    "Calves",
+    "Biceps",
+    "Triceps",
+    "Traps",
+    "Abdominals",
+    "Glutes",
+    "Quadriceps",
+    "Adductors",
+    "Abductors"
+  ];
 
-  return ( 
+  return (
     <div className="all-exercise">
-    {props.exercises ? (props.exercises.map((exercise, index) => {
-      return <div key={index}>
-        <p>{exercise.exercise_name}</p>
+      <div className="muscle-groups">
+        {muscles.map((category, index) => (
+          <button key={index} onClick={props.showMuscleGroup}>
+            {category}
+          </button>
+        ))}
       </div>
-    })) : null}
-  </div>
-    );
-}
- 
+      {props.exercises
+        ? props.exercises.map((exercise, index) => {
+            return (
+              <div key={index}>
+                <p>{exercise.exercise_name}</p>
+              </div>
+            );
+          })
+        : null}
+    </div>
+  );
+};
+
 export default AllExercises;

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -1,1 +1,7 @@
 import React from 'react';
+
+const AllExercises = (props) => {
+  return (  );
+}
+ 
+export default AllExercises;

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -6,7 +6,6 @@ const AllExercises = (props) => {
     {props.exercises ? (props.exercises.map((exercise, index) => {
       return <div key={index}>
         <p>{exercise.exercise_name}</p>
-        <button>Add</button>
       </div>
     })) : null}
   </div>

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -39,6 +39,12 @@ const AllExercises = props => {
             );
           })
         : null}
+        {props.pageNumbers ? (props.pageNumbers.map((num, index) => {
+          return <button key={index}
+            onClick={props.paginate}>
+            {num}
+          </button>
+        })) : null}
     </div>
   );
 };

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -1,6 +1,12 @@
 import React from 'react';
 
 const AllExercises = (props) => {
+  const muscles = [ 'Neck', 
+    'Lats', "Middle Back", 'Lower Back', 'Shoulders',
+     'Chest', 'Forearms', 'Hamstrings',
+    'Calves', 'Biceps', 'Triceps', 'Traps', 'Abdominals',
+    'Glutes', 'Quadriceps', "Adductors", "Abductors"];
+
   return ( 
     <div className="all-exercise">
     {props.exercises ? (props.exercises.map((exercise, index) => {

--- a/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
+++ b/workout-tracker/src/components/ExercisesLibrary/AllExercises.js
@@ -5,8 +5,7 @@ const AllExercises = (props) => {
     <div className="all-exercise">
     {props.exercises ? (props.exercises.map((exercise, index) => {
       return <div key={index}>
-        <p onClick={() =>
-           props.getExercise(exercise.id)}>{exercise.exercise_name}</p>
+        <p>{exercise.exercise_name}</p>
         <button>Add</button>
       </div>
     })) : null}

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,0 +1,1 @@
+import React from 'react';

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { fetchExercises } from '../../store/actions';
 import { connect } from 'react-redux';
 
 class ExerciseLibrary extends Component {
@@ -17,4 +18,4 @@ const mapStateToProps = state => {
   };
 };
  
-export default connect(mapStateToProps, null)(ExerciseLibrary);
+export default connect(mapStateToProps, { fetchExercises })(ExerciseLibrary);

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,1 +1,13 @@
 import React from 'react';
+
+class ExerciseLibrary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {  }
+  }
+  render() { 
+    return (  );
+  }
+}
+ 
+export default ExerciseLibrary;

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -3,14 +3,20 @@ import AllExercises from './AllExercises';
 import { fetchExercises } from '../../store/actions';
 import { connect } from 'react-redux';
 
-class ExerciseLibrary extends Component {
+class ExerciseLibrary extends React.Component {
   constructor(props) {
     super(props);
     this.state = {  }
   }
+
+  componentDidMount = () => {
+  this.props.fetchExercises();
+  };
+
   render() { 
     return ( 
-      <AllExercises exercises={this.props.exercises}  />
+      <AllExercises 
+      exercises={this.props.exercises}  />
      );
   }
 }

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -19,6 +19,7 @@ class ExerciseLibrary extends React.Component {
     return (
       <AllExercises
         exercises={this.props.exercises}
+        pageNumbers={this.props.pageNumbers}
         showMuscleGroup={e =>
            this.props.showMuscleGroup(e.target.textContent)}
       />
@@ -28,7 +29,8 @@ class ExerciseLibrary extends React.Component {
 
 const mapStateToProps = state => {
   return {
-    exercises: state.exercises.exercises
+    exercises: state.exercises.exercises,
+    pageNumbers: state.pageNumbers,
   };
 };
 

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import AllExercises from './AllExercises';
 import { fetchExercises } from '../../store/actions';
 import { connect } from 'react-redux';
 
@@ -8,7 +9,9 @@ class ExerciseLibrary extends Component {
     this.state = {  }
   }
   render() { 
-    return (  );
+    return ( 
+      <AllExercises exercises={this.props.exercises}  />
+     );
   }
 }
 

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -11,6 +11,8 @@ class ExerciseLibrary extends React.Component {
 
   componentDidMount = () => {
     this.props.fetchExercises();
+    
+    setTimeout(() => this.props.showMuscleGroup('Chest'), 1000);// That we dont see all exercises at the start
   };
 
   render() {

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,32 +1,37 @@
-import React from 'react';
-import AllExercises from './AllExercises';
-import { fetchExercises } from '../../store/actions';
-import { connect } from 'react-redux';
+import React from "react";
+import AllExercises from "./AllExercises";
+import { fetchExercises, showMuscleGroup } from "../../store/actions";
+import { connect } from "react-redux";
 
 class ExerciseLibrary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {  }
+    this.state = {};
   }
 
   componentDidMount = () => {
-  this.props.fetchExercises();
+    this.props.fetchExercises();
   };
 
-  render() { 
-    return ( 
-      <AllExercises 
-      exercises={this.props.exercises}
-      showMuscleGroup={(e) =>
-         this.props.showMuscleGroup(e.target.textContent)}  />
-     );
+  render() {
+    return (
+      <AllExercises
+        exercises={this.props.exercises}
+        showMuscleGroup={e =>
+           this.props.showMuscleGroup(e.target.textContent)}
+      />
+    );
   }
 }
 
 const mapStateToProps = state => {
   return {
-  exercises: state.exercises.exercises,
+    exercises: state.exercises.exercises
   };
 };
- 
-export default connect(mapStateToProps, { fetchExercises })(ExerciseLibrary);
+
+export default connect(
+  mapStateToProps,
+  { fetchExercises,
+  showMuscleGroup }
+)(ExerciseLibrary);

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -10,5 +10,11 @@ class ExerciseLibrary extends Component {
     return (  );
   }
 }
+
+const mapStateToProps = state => {
+  return {
+  exercises: state.exercises.exercises,
+  };
+};
  
 export default connect(mapStateToProps, null)(ExerciseLibrary);

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -16,7 +16,8 @@ class ExerciseLibrary extends React.Component {
   render() { 
     return ( 
       <AllExercises 
-      exercises={this.props.exercises}  />
+      exercises={this.props.exercises}
+      showMuscleGroup={this.props.showMuscleGroup}  />
      );
   }
 }

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 class ExerciseLibrary extends Component {
   constructor(props) {
@@ -10,4 +11,4 @@ class ExerciseLibrary extends Component {
   }
 }
  
-export default ExerciseLibrary;
+export default connect(mapStateToProps, null)(ExerciseLibrary);

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -30,7 +30,7 @@ class ExerciseLibrary extends React.Component {
 const mapStateToProps = state => {
   return {
     exercises: state.exercises.exercises,
-    pageNumbers: state.pageNumbers
+    pageNumbers: state.exercises.pageNumbers,
   };
 };
 

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -1,6 +1,6 @@
 import React from "react";
 import AllExercises from "./AllExercises";
-import { fetchExercises, showMuscleGroup } from "../../store/actions";
+import { fetchExercises, showMuscleGroup, paginate } from "../../store/actions";
 import { connect } from "react-redux";
 
 class ExerciseLibrary extends React.Component {
@@ -11,17 +11,17 @@ class ExerciseLibrary extends React.Component {
 
   componentDidMount = () => {
     this.props.fetchExercises();
-    
-    setTimeout(() => this.props.showMuscleGroup('Chest'), 1000);// That we dont see all exercises at the start
+
+    setTimeout(() => this.props.showMuscleGroup("Chest"), 1000); // That we dont see all exercises at the start
   };
 
   render() {
     return (
       <AllExercises
         exercises={this.props.exercises}
+        showMuscleGroup={e => this.props.showMuscleGroup(e.target.textContent)}
         pageNumbers={this.props.pageNumbers}
-        showMuscleGroup={e =>
-           this.props.showMuscleGroup(e.target.textContent)}
+        paginate={e => this.props.paginate(e.target.textContent)}
       />
     );
   }
@@ -30,12 +30,11 @@ class ExerciseLibrary extends React.Component {
 const mapStateToProps = state => {
   return {
     exercises: state.exercises.exercises,
-    pageNumbers: state.pageNumbers,
+    pageNumbers: state.pageNumbers
   };
 };
 
 export default connect(
   mapStateToProps,
-  { fetchExercises,
-  showMuscleGroup }
+  { fetchExercises, showMuscleGroup, paginate }
 )(ExerciseLibrary);

--- a/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
+++ b/workout-tracker/src/components/ExercisesLibrary/ExercisesLibrary.js
@@ -17,7 +17,8 @@ class ExerciseLibrary extends React.Component {
     return ( 
       <AllExercises 
       exercises={this.props.exercises}
-      showMuscleGroup={this.props.showMuscleGroup}  />
+      showMuscleGroup={(e) =>
+         this.props.showMuscleGroup(e.target.textContent)}  />
      );
   }
 }

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 export const FETCH_EXERCISES = 'FETCH_EXERCISES';
 export const SHOW_MUSCLE_GROUP = 'SHOW_MUSCLE_GROUP';
+export const PAGINATE = 'PAGINATE';
 
 const exercises = 'http://localhost:5000/exercises';
 // adress get's changed later
@@ -20,4 +21,8 @@ export const fetchExercises = () => dispatch => {
 
 export const showMuscleGroup = (muscleGroup) => {
   return { type: SHOW_MUSCLE_GROUP, muscleGroup: muscleGroup };   
+};
+
+export const paginate = (num) => {
+  return { type: PAGINATE, num: num };   
 };

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 export const FETCH_EXERCISES = 'FETCH_EXERCISES';
+export const SHOW_MUSCLE_GROUP = 'SHOW_MUSCLE_GROUP';
 
 const exercises = 'http://localhost:5000/exercises';
 // adress get's changed later
@@ -15,4 +16,8 @@ export const fetchExercises = () => dispatch => {
     .catch(err => {
    // type ERROR needs to be added (also for the redux state)
     });
+};
+
+export const ShowMuscleGroup = (muscleGroup) => {
+  return { type: SHOW_MUSCLE_GROUP, muscleGroup: muscleGroup };   
 };

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -4,3 +4,14 @@ export const FETCH_EXERCISES = 'FETCH_EXERCISES';
 
 const exercises = 'http://localhost:5000/exercises';
 // adress get's changed later
+
+export const fetchExercises = () => dispatch => {
+  return axios.get(exercises)
+    .then(res => {
+      debugger
+      dispatch({ type: FETCH_EXERCISES, exercises: res.data });
+    })
+    .catch(err => {
+     debugger
+    })
+};

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -18,6 +18,6 @@ export const fetchExercises = () => dispatch => {
     });
 };
 
-export const ShowMuscleGroup = (muscleGroup) => {
+export const showMuscleGroup = (muscleGroup) => {
   return { type: SHOW_MUSCLE_GROUP, muscleGroup: muscleGroup };   
 };

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -1,1 +1,1 @@
-// placeholder - delete file when ready
+import axios from 'axios';

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -6,12 +6,13 @@ const exercises = 'http://localhost:5000/exercises';
 // adress get's changed later
 
 export const fetchExercises = () => dispatch => {
+  // type LOADING needs to be added (also for the redux state) 
+
   return axios.get(exercises)
     .then(res => {
-      debugger
       dispatch({ type: FETCH_EXERCISES, exercises: res.data });
     })
     .catch(err => {
-     debugger
-    })
+   // type ERROR needs to be added (also for the redux state)
+    });
 };

--- a/workout-tracker/src/store/actions/index.js
+++ b/workout-tracker/src/store/actions/index.js
@@ -1,1 +1,6 @@
 import axios from 'axios';
+
+export const FETCH_EXERCISES = 'FETCH_EXERCISES';
+
+const exercises = 'http://localhost:5000/exercises';
+// adress get's changed later

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -18,7 +18,7 @@ const exercises = (state = initialState, action) => {
         copyOfExercises: filterExercisesWithoutRating
       };
 
-      case types.SHOW_CATGEGORY:
+      case type.SHOW_MUSCLE_GROUP:
         let searchResultForMuscleGroup = state.copyOfExercises.filter(exer => exer.muscle === action.muscleGroup);
 
         return { ...state, exercises: searchResultForMuscleGroup };

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -1,3 +1,24 @@
 const initialState = {
   exercises: null,
+  copyOfExercises: null
 };
+
+const exercises = (state = initialState, action) => {
+  switch (action.type) {
+    case types.FETCH_EXERCISES:
+      const filterExercisesWithoutRating = action.payload.filter(
+        exercise => exercise.exercise_ratings !== "n/a"
+      );
+
+      return {
+        ...state,
+        exercises: filterExercisesWithoutRating,
+        copyOfExercises: filterExercisesWithoutRating
+      };
+
+    default:
+      return state;
+  }
+};
+
+export default exercises;

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -8,7 +8,7 @@ const initialState = {
 const exercises = (state = initialState, action) => {
   switch (action.type) {
     case type.FETCH_EXERCISES:
-      const filterExercisesWithoutRating = action.payload.filter(
+      const filterExercisesWithoutRating = action.exercises.filter(
         exercise => exercise.exercise_ratings !== "n/a"
       );
 

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -1,8 +1,12 @@
-import * as type from '../actions';
+import * as type from "../actions";
+import { bindActionCreators } from "../../../../../../../../AppData/Local/Microsoft/TypeScript/3.5/node_modules/redux";
 
 const initialState = {
   exercises: null,
-  copyOfExercises: null
+  copyOfExercises: null,
+  currentMuscleGroup: null,
+  postsPerPage: 10,
+  pageNumbers: null
 };
 
 const exercises = (state = initialState, action) => {
@@ -18,10 +22,32 @@ const exercises = (state = initialState, action) => {
         copyOfExercises: filterExercisesWithoutRating
       };
 
-      case type.SHOW_MUSCLE_GROUP:
-        let searchResultForMuscleGroup = state.copyOfExercises.filter(exer => exer.muscle === action.muscleGroup);
+    case type.SHOW_MUSCLE_GROUP:
+      let searchResultForMuscleGroup = state.copyOfExercises.filter(
+        exercise => exercise.muscle === action.muscleGroup
+      );
 
-        return { ...state, exercises: searchResultForMuscleGroup };
+      const indexOfLastPost = 1 * state.postsPerPage;
+
+      const indexOfFirstPost = indexOfLastPost - state.postsPerPage;
+
+      const currentPosts = searchResultForMuscleGroup.slice(
+        indexOfFirstPost,
+        indexOfLastPost
+      );
+
+      const totalPosts = searchResultForMuscleGroup.length;
+
+      for (let i = 1; i <= Math.ceil(totalPosts / state.postsPerPage); i++) {
+        pageNumbers.push(i);
+      }
+
+      return {
+        ...state,
+        exercises: currentPosts,
+        pageNumbers: pageNumbers,
+        currentMuscleGroup: action.muscleGroup
+      };
 
     default:
       return state;

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -1,0 +1,3 @@
+const initialState = {
+  exercises: null,
+};

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -18,6 +18,11 @@ const exercises = (state = initialState, action) => {
         copyOfExercises: filterExercisesWithoutRating
       };
 
+      case types.SHOW_CATGEGORY:
+        let searchResultForMuscleGroup = state.copyOfExercises.filter(exer => exer.muscle === action.muscleGroup);
+
+        return { ...state, exercises: searchResultForMuscleGroup };
+
     default:
       return state;
   }

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -1,5 +1,4 @@
 import * as type from "../actions";
-import { bindActionCreators } from "../../../../../../../../AppData/Local/Microsoft/TypeScript/3.5/node_modules/redux";
 
 const initialState = {
   exercises: null,
@@ -27,11 +26,11 @@ const exercises = (state = initialState, action) => {
         exercise => exercise.muscle === action.muscleGroup
       );
 
-      const indexOfLastPost = 1 * state.postsPerPage;
+      const indexOfLastPost = state.postsPerPage;
 
       const indexOfFirstPost = indexOfLastPost - state.postsPerPage;
 
-      const currentPosts = searchResultForMuscleGroup.slice(
+      const currentExercises = searchResultForMuscleGroup.slice(
         indexOfFirstPost,
         indexOfLastPost
       );
@@ -44,10 +43,26 @@ const exercises = (state = initialState, action) => {
 
       return {
         ...state,
-        exercises: currentPosts,
+        exercises: currentExercises,
         pageNumbers: pageNumbers,
         currentMuscleGroup: action.muscleGroup
       };
+
+    case type.PAGINATE:
+      let searchForMuscleGroup = state.copyOfExercises.filter(
+        exercise => exercise.muscle === state.currentMuscleGroup
+      );
+
+      const indexOfTheLastPost = action.num * state.postsPerPage;
+
+      const indexOfTheFirstPost = indexOfTheLastPost - state.postsPerPage;
+
+      const theCurrentExercises = searchForMuscleGroup.slice(
+        indexOfTheFirstPost,
+        indexOfTheLastPost
+      );
+
+      return { ...state, exercises: theCurrentExercises };
 
     default:
       return state;

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -37,6 +37,8 @@ const exercises = (state = initialState, action) => {
 
       const totalPosts = searchResultForMuscleGroup.length;
 
+      let pageNumbers = [];
+
       for (let i = 1; i <= Math.ceil(totalPosts / state.postsPerPage); i++) {
         pageNumbers.push(i);
       }

--- a/workout-tracker/src/store/reducers/exercises.js
+++ b/workout-tracker/src/store/reducers/exercises.js
@@ -1,3 +1,5 @@
+import * as type from '../actions';
+
 const initialState = {
   exercises: null,
   copyOfExercises: null
@@ -5,7 +7,7 @@ const initialState = {
 
 const exercises = (state = initialState, action) => {
   switch (action.type) {
-    case types.FETCH_EXERCISES:
+    case type.FETCH_EXERCISES:
       const filterExercisesWithoutRating = action.payload.filter(
         exercise => exercise.exercise_ratings !== "n/a"
       );

--- a/workout-tracker/src/store/reducers/index.js
+++ b/workout-tracker/src/store/reducers/index.js
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
+import exercises from './exercises';
 
 const appReducer = combineReducers({
-  //
+  exercises: exercises,
 });
 
 const rootReducer = (state, action) => {


### PR DESCRIPTION
## What does this PR do
This Pull Request is for adding a pagination system to the multi exercise view

## Description of task to be completed

- add pageNumbers, postsPerPage and currentMuscleGroup redux state

- create action for pagination

- change the showMuscleGroup action in the reducer for exercises

- map over the pageNumbers array to display the buttons for 10 exercises per muscle group

## What are the relevant Trello board stories
https://trello.com/c/Nip2r1YC/84-as-a-user-i-want-to-be-able-to-see-only-10-exercises-in-the-multi-exercises-view

## How should this manually be tested

-start locally server

-download branch

-npm install

-npm start

-import ExerciseLibrary.js in App.js and add it to the App component