### PR TITLE
Fix video playing when modal closes

### DIFF
--- a/workout-tracker/src/store/reducers/workouts.js
+++ b/workout-tracker/src/store/reducers/workouts.js
@@ -52,7 +52,6 @@ const workouts = (state = initialState, action) => {
       const filterCurrentExercise = state.allExercises.filter(
         exercise => exercise.exercise_name === action.current_exercise
       );
-      debugger;
       return {
         ...state,
         currentExercise: filterCurrentExercise

--- a/workout-tracker/src/views/Settings/Settings.js
+++ b/workout-tracker/src/views/Settings/Settings.js
@@ -186,8 +186,6 @@ class Settings extends React.Component {
       push_notification: this.state.push_notification === "true" ? true : false
     };
 
-    debugger;
-
     this.props.updateSettings(updatedSettings);
 
     this.setState({

--- a/workout-tracker/src/views/WorkoutSession/WorkoutSession.js
+++ b/workout-tracker/src/views/WorkoutSession/WorkoutSession.js
@@ -265,15 +265,13 @@ class WorkoutSession extends React.Component {
             onCancel={this.handleCancel}
             onOk={this.handleOk}
           >
-            <div className="video">
-              <video width="100%" height="auto" autoPlay controls>
-                <source
-                  src={this.props.currentExercise[0].video}
-                  type="video/mp4"
-                />
-                Your browser does not support the video tag.
-              </video>
-            </div>
+            {this.state.visible && <video width="100%" height="auto" autoPlay controls>
+              <source
+                src={this.props.currentExercise[0].video}
+                type="video/mp4"
+              />
+              Your browser does not support the video tag.
+            </video>}
           </Modal>
         ) : null}
       </StyledWorkoutSession>


### PR DESCRIPTION
##  What does this PR do
This PR fixes the bug experienced when the video continues to play when modal is closed.

##  Description of tasks to be completed
- remove debugger
- load video only when modal is visible

##  How should this manually be tested
- clone this repository `git clone https://github.com/labseu2-workout-tracker/client.git`
- checkout this branch `git checkout fix-video-playing-when-modal-closes`
- `yarn install`
- `yarn run server`
- go the workout sessions page and play around with the video instructions

##  What are the relevant Trello board stories
[When the user clicks x on the video the audio continues to play](https://trello.com/c/CTSGw2V9/172-when-the-user-clicks-x-on-the-video-the-audio-continues-to-play)

[When the video is playing and a user clicks next then the video doesn't change](https://trello.com/c/hatPFwb0/170-when-the-video-is-playing-and-a-user-clicks-next-then-the-video-doesnt-change)
