### PR TITLE
Loading emote

### DIFF
--- a/workout-tracker/src/views/UserPage/MyWorkouts/MyWorkouts.js
+++ b/workout-tracker/src/views/UserPage/MyWorkouts/MyWorkouts.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { fetchWorkoutDetails, deleteWorkout } from '../../../store/actions/workoutsActions';
 import {Link } from 'react-router-dom';
+import { withRouter } from 'react-router';
+import { Empty } from 'antd';
 // import styled from 'styled-components';
 
 // const StyledWorkoutView = styled.div``;
@@ -10,8 +12,12 @@ class WorkoutView extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+
+
+
   }
   render() {
+   
     return <div>
           <h1>
             My Workouts
@@ -29,7 +35,7 @@ class WorkoutView extends React.Component {
                 Delete Workout
               </p>
         </div> 
-      })) : <h1>You choosed no Workouts so far</h1>}
+      })) : (<Link to='/Workouts'><Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={'Add some workouts'}/></Link>)}
     </div>
             </div>;
   }

--- a/workout-tracker/src/views/UserPage/Stats/Charts/ChartContainer.js
+++ b/workout-tracker/src/views/UserPage/Stats/Charts/ChartContainer.js
@@ -14,14 +14,14 @@ const StyledChartContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  height: 100%;
+  height: 70%;
 
   .off {
     display: none;
   }
 
   .weekly , .monthly, .yearly {
-  width: 100%;
+  width: 70%;
   }
 `;
 

--- a/workout-tracker/src/views/UserPage/Stats/UserHistory/UserHistory.js
+++ b/workout-tracker/src/views/UserPage/Stats/UserHistory/UserHistory.js
@@ -142,6 +142,7 @@ export default connect(
 const StyledUserHistory = styled.div`
   width: 50%;
   margin: 0 auto; 
+ 
   ol {
     padding: 10px;
   }
@@ -156,6 +157,7 @@ const StyledUserHistory = styled.div`
     font-size: 1.5rem;
     color: black;
     border: 1px solid gray;
+    border-radius:10px;
   }
   h4 {
     position: relative;

--- a/workout-tracker/src/views/UserPage/Stats/UserHistory/UserHistory.js
+++ b/workout-tracker/src/views/UserPage/Stats/UserHistory/UserHistory.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { Empty } from 'antd';
 import { fetchWorkoutsHistory } from "../../../../store/actions/historyActions";
 import { fetchWorkouts } from "../../../../store/actions/workoutsActions";
 import { connect } from "react-redux";
@@ -38,11 +39,13 @@ class SessionHistory extends React.Component {
     let history = this.props.history;
     let workouts = this.props.workouts;
 
+    console.log(history)
+
     return (
       <div>
         <h2>Here you can check out the work you have done!</h2>
         <StyledUserHistory>
-          {history ? (
+          {history.length !== 0 ? (
             <div>
               {history
                 .slice(this.state.minValue, this.state.maxValue)
@@ -112,9 +115,7 @@ class SessionHistory extends React.Component {
                 total={this.props.history.length}
               />
             </div>
-          ) : (
-            <p>You have no workout history at the moment</p>
-          )}
+          ) : <Empty description={'No Data!'} />}
         </StyledUserHistory>
       </div>
     );
@@ -136,10 +137,11 @@ export default connect(
   }
 )(SessionHistory);
 
-const StyledUserHistory = styled.div`
-  width: 100%;
-  /* margin: 0 auto; */
 
+
+const StyledUserHistory = styled.div`
+  width: 50%;
+  margin: 0 auto; 
   ol {
     padding: 10px;
   }


### PR DESCRIPTION
##  What does this PR do
If not session display an emote with an empty box.
If no workouts display an emote with an empty box and that is a link to redirect to workouts.
Chart size changed to make everything else more visible.
Small css changes for the session list

##  Description of task to be completed


##  How should this manually be tested
Create a new account were the session list is empty to check the changes.
Delete if you have the workouts from the user workouts to check the changes.

##  What are the relevant Trello board stories
https://trello.com/c/6ZGX9zOS/194-as-a-user-i-want-to-see-a-loading-gif-while-the-data-is-being-loaded-on-the-webpage

##  Screenshots (If appropriate)
![image](https://user-images.githubusercontent.com/25125203/64777992-1900de80-d553-11e9-944d-87c51a85caa9.png)


##  Questions (If any): 