### PR TITLE
Fe nav mobile

### DIFF
--- a/workout-tracker/src/App.js
+++ b/workout-tracker/src/App.js
@@ -66,15 +66,22 @@ class App extends Component {
           <Route exact path="/contact" component={ContactPage} />
           <Route path="/login" render={props => <LoginPage {...props} />} />
           <Route path="/signup" render={props => <SignupPage {...props} />} />
-          <PrivateRoute path={"/Dashboard"} component={Stats} />
-          <PrivateRoute path={"/Exercises"} component={ExercisesLibrary} />
-          <PrivateRoute path={"/Settings"} component={Settings} />
-          <PrivateRoute path={"/Workouts"} component={Workouts} />
-          <PrivateRoute path={"/Workout_session"} component={WorkoutSession} />
           <Redirect to="/" />
         </Switch>
       </>
     );
+    if (Auth.isAuthenticated()) {
+      routes = (
+      <Switch>
+        <PrivateRoute path={"/Dashboard"} component={Stats} />
+        <PrivateRoute path={"/Exercises"} component={ExercisesLibrary} />
+        <PrivateRoute path={"/Settings"} component={Settings} />
+        <PrivateRoute path={"/Workouts"} component={Workouts} />
+        <PrivateRoute path={"/Workout_session"} component={WorkoutSession} />
+        <Redirect to="/workouts" />
+      </Switch>
+      )
+    }
 
     return (
       <>

--- a/workout-tracker/src/components/Layout/Layout.js
+++ b/workout-tracker/src/components/Layout/Layout.js
@@ -54,20 +54,3 @@ const StyledContainer = styled.section`
 `
 
 export default MainLayout;
-
-// import React from 'react';
-// import "antd/dist/antd.css";
-// import { Layout } from "antd";
-// import './Layout.css';
-
-// const { Header, Content } = Layout;
-
-// const MainLayout = props => (
-//   <>
-//     <Header className="main-header">{props.header}</Header>
-//     {props.mobileNav}
-//     <Content className="content">{props.routes}</Content>
-//   </>
-// );
-
-// export default MainLayout;

--- a/workout-tracker/src/components/Layout/Layout.js
+++ b/workout-tracker/src/components/Layout/Layout.js
@@ -14,7 +14,14 @@ class MainLayout extends React.Component {
         {!Auth.isAuthenticated() ? <Header>{this.props.header}</Header> : '' }
         {this.props.mobileNav}
         <div className='content-container'>
-        {Auth.isAuthenticated() ? <Sider>{this.props.sider}</Sider> : '' }
+        {Auth.isAuthenticated()
+        ? <Sider
+            breakpoint="lg"
+            collapsedWidth="0"
+          >
+            {this.props.sider}
+          </Sider>
+          : '' }
         <Content>{this.props.routes}</Content>
         </div>
 


### PR DESCRIPTION
##  What does this PR do
This PR hides sider when user is on mobile. User can toggle hamburger menu for sider to appear.
 Also, PR prohibits a logged in user from visiting login, signup

##  What are the relevant Trello board stories
https://trello.com/c/WIwptZb9/220-sidebar-to-be-hidden-in-mobile-view-and-restrict-access-to-non-private-routes-when-logged-in

##  Screenshots (If appropriate)
![mobile-sider](https://user-images.githubusercontent.com/5153613/64851465-79ae1b00-d628-11e9-8bff-821704367ccb.gif)