### PR TITLE
Modify custom workouts page

### DIFF
--- a/workout-tracker/src/components/Exercises/AllExercises.js
+++ b/workout-tracker/src/components/Exercises/AllExercises.js
@@ -64,7 +64,7 @@ class AllExercises extends Component {
                 )}
               </ReactHeight>
             </div>
-            <div style={{ marginTop: this.state.topBarHeight + 15 }}>
+            <div style={{ marginTop: this.state.topBarHeight + 15, padding: '3rem' }}>
               {/* <SideBar
                 marginTop={this.state.topBarHeight + 15}
                 newWorkout={this.props.newWorkout}

--- a/workout-tracker/src/components/Exercises/AllExercises.js
+++ b/workout-tracker/src/components/Exercises/AllExercises.js
@@ -10,7 +10,7 @@ import {
   searchExercise
 } from "../../store/actions/exerciseActions";
 import { createWorkout } from "../../store/actions/workoutsActions";
-import { Spin, PageHeader } from "antd";
+import { Spin, PageHeader, AutoComplete, Input, Icon } from "antd";
 import { ReactHeight } from "react-height";
 import { connect } from "react-redux";
 
@@ -51,10 +51,25 @@ class AllExercises extends Component {
                 onHeightReady={height => this.setTopBarHeight(height)}
               >
                 {!this.state.saveExercise ? (
-                  <FilterExercises
+                  <><FilterExercises
                     {...this.props}
                     filterMuscles={this.filterMuscles}
                   />
+                  <AutoComplete
+                    dataSource={[...new Set(this.props.exercises)].map(e => (
+                      <AutoComplete.Option key={e.exercise_name} text={e.exercise_name}>
+                        {e.exercise_name}
+                      </AutoComplete.Option>
+                    ))}
+                    style={{ width: 300, margin: "1rem auto" }}
+                    onChange={exercise_name => {this.props.searchExercise(exercise_name)}}
+                    optionLabelProp="text"
+                  >
+                    <Input
+                      suffix={<Icon type="search" className="certain-category-icon" />}
+                      placeholder="Search Exercises"
+                    />
+                  </AutoComplete></>
                 ) : (
                   <PageHeader
                     onBack={() => this.setState({ saveExercise: false })}
@@ -154,6 +169,7 @@ const topBar = {
   position: "fixed",
   top: 0,
   width: "100%",
+  textAlign: 'center',
   zIndex: 5,
   background: "#fff",
   boxShadow: "0px 0px 5px 5px rgba(0, 0, 0, .05)"

--- a/workout-tracker/src/components/Exercises/AllExercises.js
+++ b/workout-tracker/src/components/Exercises/AllExercises.js
@@ -10,7 +10,7 @@ import {
   searchExercise
 } from "../../store/actions/exerciseActions";
 import { createWorkout } from "../../store/actions/workoutsActions";
-import { Spin, Button, PageHeader } from "antd";
+import { Spin, PageHeader } from "antd";
 import { ReactHeight } from "react-height";
 import { connect } from "react-redux";
 
@@ -148,21 +148,6 @@ export default connect(
     createWorkout
   }
 )(AllExercises);
-
-const floatingButtons = {
-  position: "fixed",
-  right: "2rem",
-  top: "1rem",
-  zIndex: 7
-};
-
-const bottom = {
-  top: "unset",
-  bottom: "1rem",
-  left: "1rem",
-  width: "calc(25% - 2rem)",
-  boxShadow: "0px 0px 10px 5px rgba(0, 0, 0, .15)"
-};
 
 const topBar = {
   padding: "1rem",

--- a/workout-tracker/src/index.js
+++ b/workout-tracker/src/index.js
@@ -32,7 +32,7 @@ function loadFromLocalStorage() {
 
 const persistedState = loadFromLocalStorage();
 
-const store = createStore(rootReducer, persistedState, applyMiddleware(thunk));
+const store = createStore(rootReducer, applyMiddleware(thunk));
 
 store.subscribe(() => saveToLocalStorage(store.getState()));
 

--- a/workout-tracker/src/index.js
+++ b/workout-tracker/src/index.js
@@ -32,7 +32,7 @@ function loadFromLocalStorage() {
 
 const persistedState = loadFromLocalStorage();
 
-const store = createStore(rootReducer, applyMiddleware(thunk));
+const store = createStore(rootReducer, persistedState, applyMiddleware(thunk));
 
 store.subscribe(() => saveToLocalStorage(store.getState()));
 

--- a/workout-tracker/src/store/actions/workoutsActions.js
+++ b/workout-tracker/src/store/actions/workoutsActions.js
@@ -1,6 +1,5 @@
 import { axiosWithAuth } from "../axiosWithAuth";
 // import axiosWithAuth from 'axios';
-
 // actions
 export const FETCH_WORKOUTS = "FETCH_WORKOUTS";
 export const FETCH_WORKOUT_DETAILS = "FETCH_WORKOUT_DETAILS";
@@ -32,7 +31,6 @@ export const addWorkoutDetails = workoutDetails => {
 };
 
 export const createWorkout = (fullWorkoutDetails, history) => dispatch => {
-  console.log(fullWorkoutDetails)
   dispatch({
     type: LOADING_CREATE_WORKOUT,
     payload: true
@@ -47,10 +45,9 @@ export const createWorkout = (fullWorkoutDetails, history) => dispatch => {
       history.push('/workouts');
     })
     .catch(error => {
-      console.log(error.response.data)
       dispatch({
         type: CREATE_WORKOUT_ERROR,
-        payload: "Error creating workout. Please Try Again"
+        payload: error.response.data.errorMessage
       });
     })
     .finally(() => ({
@@ -166,7 +163,7 @@ export const getSavedWorkout = () => dispatch => {
   axiosWithAuth()
     .get(`${workouts}/all-saved/${userId}`)
     .then(res => {
-      dispatch(genericAction(ADD_WORKOUT_SUCCESS, res.data));
+      dispatch(genericAction(GET_SAVED_WORKOUT_SUCCESS, res.data));
     })
     .catch(err => {
       dispatch(genericAction(GET_SAVED_WORKOUT_FAILURE, err));

--- a/workout-tracker/src/store/reducers/workouts.js
+++ b/workout-tracker/src/store/reducers/workouts.js
@@ -11,17 +11,6 @@ const initialState = {
   error: null,
 };
 
-const removeDuplicates = (arr, comp) => {
-  const unique = arr
-    .map(workout => workout[comp])
-    .map((workout, index, array) => array.indexOf(workout) === index && index)
-
-    .filter(workout => arr[workout])
-    .map(workout => arr[workout]);
-
-  return unique;
-};
-
 const workouts = (state = initialState, action) => {
   switch (action.type) {
     case type.ADD_WORKOUT_DETAILS:

--- a/workout-tracker/src/utils/AddWorkoutButton.js
+++ b/workout-tracker/src/utils/AddWorkoutButton.js
@@ -4,13 +4,17 @@ import { Button, Tooltip } from 'antd'
 const AddWorkoutButton = (props) => {
   return (
     <Tooltip Tooltip title = "Add new workout">
-         <Button type = "primary" size = "large" block style = {myStyle} onClick={props.modal}>Create Custom Workout</Button>
+         <Button type = "primary" size = "large" style = {myStyle} onClick={props.modal}>Create Custom Workout</Button>
     </Tooltip>
   )
 }
 
 const myStyle = {
-  boxShadow: "0px 0px 10px 5px rgba(0, 0, 0, .15)",
+  position: 'fixed',
+  top: '2rem',
+  right: '2rem',
+  zIndex: '3',
+  boxShadow: "0px 0px 5px 5px rgba(0, 0, 0, .15)",
   fontWeight: 'bold',
 }
 

--- a/workout-tracker/src/views/AboutUs/AboutUs.css
+++ b/workout-tracker/src/views/AboutUs/AboutUs.css
@@ -2,22 +2,24 @@ html {
   font-size: 15px;
   font-family: 'Roboto', sans-serif;
 }
+
 body {
   overflow-x: hidden;
 }
+
 a {
   text-decoration: none;
 }
-p {
-  padding: 2rem;
-}
+
 section {
   padding: 10 rem 0;
   background-color: #ffffff;
 }
-.container{
+
+.container {
   align-content: center;
 }
+
 /* Workout img styling */
 .workout-img {
   width: 15rem;
@@ -28,6 +30,7 @@ section {
   margin-top: -10rem;
   border: 0.7rem solid #c7d9eef9;
 }
+
 .workout-card {
   width: 30rem;
   background-color: #c7d9eef9;
@@ -40,11 +43,13 @@ section {
   border-radius: 0 0 2rem 2rem;
   box-shadow: 1.5rem 1.5rem 3rem rgba(0, 0, 0, 0.2);
 }
+
 .workout-card h1 {
   font-size: 1.7rem;
   color: #6bbdfa;
   margin: 0.5rem;
 }
+
 .workout-card .btn {
   padding: 0.8rem 2.5rem;
   background-color: #6bbdfa;
@@ -55,27 +60,32 @@ section {
   font-size: 1.4rem;
   transition: all 0.7s;
 }
+
 .workout-card .btn:hover {
   transform: translateY(-2px);
   box-shadow: 0.5rem 0.5rem 3rem rgba(0, 0, 0, 0.2);
 }
+
 .workout-card .btn:active {
   transform: translateY(0);
   box-shadow: none;
 }
+
 .workout-card p {
   color: #655f69;
   font-size: 1rem;
   text-align: start;
   font-weight: 300;
 }
+
 .coolstuff {
   font-size: 2.5rem;
   color: #6bbdfa;
   margin: 1.5rem;
-  align-content: center; 
+  align-content: center;
   font-family: 'Viga', sans-serif;
 }
+
 /* card workouts */
 
 .heading {
@@ -87,6 +97,7 @@ section {
   color: #6bbdfa;
   position: relative;
 }
+
 .heading::after {
   content: '';
   width: 10rem;
@@ -98,12 +109,14 @@ section {
   transform: translateX(-50%);
   border-radius: 2rem;
 }
+
 .card-wrapper {
   display: flex;
   align-items: center;
   align-content: center;
   flex-direction: column;
 }
+
 .card {
   width: 30rem;
   background-color: #c7d9eef9;
@@ -115,6 +128,7 @@ section {
   border-radius: 0 0 2rem 2rem;
   box-shadow: 1.5rem 1.5rem 3rem rgba(0, 0, 0, 0.2);
 }
+
 .card .card-img {
   width: 100%;
   height: 20rem;
@@ -122,6 +136,7 @@ section {
   -webkit-clip-path: polygon(0 0, 100% 0, 100% 49%, 0% 100%);
   clip-path: polygon(0 0, 100% 0, 100% 49%, 0% 100%);
 }
+
 .profile-img {
   width: 15rem;
   height: 15rem;
@@ -138,19 +153,22 @@ section {
   margin: .9rem;
   font-family: 'Viga', sans-serif;
 }
+
 .team {
   font-size: 3.5rem;
   color: #6bbdfa;
-  text-align:center;
+  text-align: center;
   margin: 1.5rem;
   font-family: 'Viga', sans-serif;
 }
+
 .job-title {
   color: #655f69;
   font-family: 'Viga', sans-serif;
   font-size: 1.5rem;
   font-weight: 300;
 }
+
 .about {
   font-size: 1.3rem;
   margin: 1.5rem 0;
@@ -158,6 +176,7 @@ section {
   color: #ffffff;
   font-weight: 250;
 }
+
 .card .btn {
   padding: 0.8rem 2.5rem;
   background-color: #6bbdfa;
@@ -168,10 +187,12 @@ section {
   font-size: 1.4rem;
   transition: all 0.7s;
 }
+
 .card .btn:hover {
   transform: translateY(-2px);
   box-shadow: 0.5rem 0.5rem 3rem rgba(0, 0, 0, 0.2);
 }
+
 .card .btn:active {
   transform: translateY(0);
   box-shadow: none;
@@ -195,21 +216,26 @@ section {
 .fa-linkedin {
   color: #0e76a8;
 }
+
 .fa-twitter-square {
   color: #0ea7e9;
 }
+
 .fa-facebook-square {
   color: #3b5998;
 }
+
 .fa-github-square {
   color: #333;
 }
+
 .fa-twitter-square:hover,
 .fa-facebook-square:hover,
 .fa-linkedin:hover,
 .fa-github-square:hover {
   color: #980cc6;
 }
+
 @media screen and (min-width: 300px) {
   .card-wrapper {
     flex-direction: row;
@@ -217,6 +243,7 @@ section {
     justify-content: center;
     align-items: center;
   }
+
   .card {
     margin: 2rem;
     transition: transfom 0.5s;

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -96,11 +96,18 @@ class AllExercises extends Component {
               <ReactHeight
                 onHeightReady={height => this.setTopBarHeight(height)}
               >
+                {this.state.saveExercise && <PageHeader
+                  onBack={() => this.setState({ saveExercise: false })}
+                  title="Add Sets"
+                />}
                 <Button type="link" onClick={this.showModal}><Badge style={{ marginRight: "1rem" }} count={this.props.selectedExercises.length}>
                   <IconFont style={{ fontSize: "2rem", marginRight: "1rem" }} type="icon-musclewhitebig-copy" />
                </Badge></Button>
-               <Button type="link" onClick={this.showFilters}> <Icon style={{ fontSize: "2rem", marginLeft: "1rem" }} type="filter" /></Button>
-               <AutoComplete
+               {!this.state.saveExercise && 
+                <Button type="link" onClick={this.showFilters}> 
+                  <Icon style={{ fontSize: "2rem", marginLeft: "1rem" }} type="filter" />
+                </Button>}
+                {!this.state.saveExercise && <AutoComplete
                   dataSource={[...new Set(this.props.exercises)].map(e => (
                     <AutoComplete.Option key={e.exercise_name} text={e.exercise_name}>
                       {e.exercise_name}
@@ -114,7 +121,8 @@ class AllExercises extends Component {
                     suffix={<Icon type="search" className="certain-category-icon" />}
                     placeholder="Search Exercises"
                   />
-                </AutoComplete>
+                </AutoComplete>}
+                
                 <div className="top-bar">
                 {!this.state.saveExercise ? (
                   <FilterExercises
@@ -198,7 +206,7 @@ class AllExercises extends Component {
               <SelectedExercises
                 remove={this.props.removeFromSelectedExercises}
                 exercises={this.props.selectedExercises}
-                saveExercise={this.props.saveExercise}
+                saveExercise={this.state.saveExercise}
               />
             </Modal>
             <Modal

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -180,6 +180,7 @@ class AllExercises extends Component {
                     createWorkout={this.props.createWorkout}
                     loading={this.props.loadingWorkouts}
                     history={this.props.history}
+                    error={this.props.errorWorkouts}
                   />
                 )}
               </div>
@@ -208,7 +209,7 @@ class AllExercises extends Component {
               onOk={this.handleOk}
               onCancel={this.handleCancel}
               footer={[
-                <Button 
+                !this.state.saveExercise && <Button 
                   key="submit" 
                   disabled={!this.props.selectedExercises.length}
                   type="primary"
@@ -303,7 +304,7 @@ const StyledContainer = styled.div`
     box-shadow: 0px 0px 10px 5px rgba(0, 0, 0, .15);
   }
 
-  @media screen and (min-width: 767px) {
+  @media screen and (min-width: 769px) {
     .mobile-menu {
       display: none;
     }

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -155,7 +155,7 @@ class AllExercises extends Component {
                 
               </ReactHeight>
             </div>
-            <div style={{ marginTop: this.state.topBarHeight + 15 }}>
+            <div style={{ marginTop: this.state.topBarHeight + 15,  padding: '3rem 1rem' }}>
               <div className="side-bar">
               <SideBar
                 marginTop={this.state.topBarHeight + 15}

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -30,6 +30,7 @@ function showConfirm(history) {
     content: 'When you click on exit, you will lose all selected exercises and sets',
     okText: 'Exit',
     onOk() {
+      window.localStorage.removeItem('state');
       return history.push("/workouts")
     },
     onCancel() {},

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -96,6 +96,7 @@ class AllExercises extends Component {
               <ReactHeight
                 onHeightReady={height => this.setTopBarHeight(height)}
               >
+                <div className="mobile-menu">
                 {this.state.saveExercise && <PageHeader
                   onBack={() => this.setState({ saveExercise: false })}
                   title="Add Sets"
@@ -106,14 +107,14 @@ class AllExercises extends Component {
                {!this.state.saveExercise && 
                 <Button type="link" onClick={this.showFilters}> 
                   <Icon style={{ fontSize: "2rem", marginLeft: "1rem" }} type="filter" />
-                </Button>}
+                </Button>}</div>
                 {!this.state.saveExercise && <AutoComplete
                   dataSource={[...new Set(this.props.exercises)].map(e => (
                     <AutoComplete.Option key={e.exercise_name} text={e.exercise_name}>
                       {e.exercise_name}
                     </AutoComplete.Option>
                   ))}
-                  style={{ width: 300, marginLeft: "1rem" }}
+                  style={{ width: 300, margin: "1rem auto" }}
                   onChange={exercise_name => {this.props.searchExercise(exercise_name)}}
                   optionLabelProp="text"
                 >
@@ -286,6 +287,12 @@ const StyledContainer = styled.div`
     left: 1rem;
     width: calc(25% - 2rem);
     box-shadow: 0px 0px 10px 5px rgba(0, 0, 0, .15);
+  }
+
+  @media screen and (min-width: 767px) {
+    .mobile-menu {
+      display: none;
+    }
   }
 
   @media screen and (max-width: 768px) {

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -21,6 +21,20 @@ import styled from "styled-components";
 const IconFont = Icon.createFromIconfontCN({
   scriptUrl: '//at.alicdn.com/t/font_1394475_0d6q9r1xk5c.js',
 });
+
+const { confirm } = Modal;
+
+function showConfirm(history) {
+  confirm({
+    title: 'Are you sure you want to exit this page?',
+    content: 'When you click on exit, you will lose all selected exercises and sets',
+    okText: 'Exit',
+    onOk() {
+      return history.push("/workouts")
+    },
+    onCancel() {},
+  });
+}
 class AllExercises extends Component {
   state = {
     topBarHeight: "",
@@ -175,7 +189,7 @@ class AllExercises extends Component {
               size="large"
               icon="close"
               className="fixed-button"
-              onClick={() => this.props.history.push("/workouts")}
+              onClick={() => showConfirm(this.props.history)}
             ></Button>
             {
               !this.state.saveExercise && <Button

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -110,7 +110,8 @@ class AllExercises extends Component {
               !this.state.saveExercise && <Button
               type="primary"
               size="large"
-              icobn="check"
+              icon="check"
+              disabled={!this.props.selectedExercises.length}
               style={{ ...floatingButtons, ...bottom }}
               onClick={() => this.setState({ saveExercise: true })}
             >

--- a/workout-tracker/src/views/customWorkout/AllExercises.js
+++ b/workout-tracker/src/views/customWorkout/AllExercises.js
@@ -70,6 +70,7 @@ class AllExercises extends Component {
                 marginTop={this.state.topBarHeight + 15}
                 newWorkout={this.props.newWorkout}
                 selectedExercises={this.props.selectedExercises}
+                saveExercise={this.state.saveExercise}
               />
               <div
                 style={{

--- a/workout-tracker/src/views/customWorkout/DisplayExercise.js
+++ b/workout-tracker/src/views/customWorkout/DisplayExercise.js
@@ -151,6 +151,22 @@ const StyledList = styled(List)`
     width: 100%;
     bottom: 0;
   }
+  @media screen and (max-width: 992px) {
+    .ant-card-bordered {
+      height: calc(100% - 1rem);
+      width: 45vw;
+      margin-bottom: 16px;
+      position: relative;
+    }
+  }
+  @media screen and (max-width: 560px) {
+    .ant-card-bordered {
+      height: calc(100% - 1rem);
+      width: 60vw;
+      margin-bottom: 16px;
+      position: relative;
+    }
+  }
 `
 
 export default withRouter(DisplayExercise);

--- a/workout-tracker/src/views/customWorkout/DisplayExercise.js
+++ b/workout-tracker/src/views/customWorkout/DisplayExercise.js
@@ -65,11 +65,11 @@ class DisplayExercise extends Component {
                   <Avatar shape="square" size={64} src={item.picture_two} />
                 </Row>
                 <h3>{item.exercise_name}</h3>
-                <>
-                  Type: <strong>{item.type}</strong><br />
-                  Target: <strong>{item.muscle}</strong> muscle<br />
-                  Equipment: <strong>{item.equipment}</strong><br />
-                </>
+                <div style={{ textAlign: "left" }}>
+                  Type: <em>{item.type}</em><br />
+                  Target: <em>{item.muscle}</em><br />
+                  Equipment: <em>{item.equipment}</em><br />
+                </div>
               </Card>
             </List.Item>
           )}
@@ -151,7 +151,7 @@ const StyledList = styled(List)`
     width: 100%;
     bottom: 0;
   }
-  @media screen and (max-width: 992px) {
+  @media screen and (max-width: 768px) {
     .ant-card-bordered {
       height: calc(100% - 1rem);
       width: 45vw;
@@ -162,7 +162,7 @@ const StyledList = styled(List)`
   @media screen and (max-width: 560px) {
     .ant-card-bordered {
       height: calc(100% - 1rem);
-      width: 60vw;
+      width: 70vw;
       margin-bottom: 16px;
       position: relative;
     }

--- a/workout-tracker/src/views/customWorkout/DisplayExercise.js
+++ b/workout-tracker/src/views/customWorkout/DisplayExercise.js
@@ -143,7 +143,12 @@ const StyledList = styled(List)`
   }
 
   .ant-card-body {
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
+    text-align: center;
+    
+    h3 {
+      margin-top: 1rem;
+    }
   }
 
   .ant-card-actions {

--- a/workout-tracker/src/views/customWorkout/DisplayExercise.js
+++ b/workout-tracker/src/views/customWorkout/DisplayExercise.js
@@ -27,16 +27,17 @@ class DisplayExercise extends Component {
     });
   };
   render() {
+    this.props.dataSource.sort((a, b) => a.exercise_name < b.exercise_name ? -1 : a.exercise_name > b.exercise_name ? 1 : 0)
     return (
       <div>
         <StyledList
           itemLayout="horizontal"
-          grid={{ gutter: 12, md: 2, lg: 3, xl: 4, xxl: 6}}
+          grid={{ gutter: 36, sm: 2, lg: 3, xl: 3, xxl: 4}}
           pagination={{
             pageSize: 24,
             showLessItems: true
           }}
-          dataSource={this.props.dataSource.sort((a, b) => a.id - b.id)}
+          dataSource={this.props.dataSource}
           renderItem={item => (
             <List.Item>
               <Card

--- a/workout-tracker/src/views/customWorkout/FilterExercises.js
+++ b/workout-tracker/src/views/customWorkout/FilterExercises.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import FilterTag from "./FilterTag";
-import {  Input, Icon, AutoComplete } from "antd";
 
 export default class FilterExercises extends Component {
   render() {
@@ -56,21 +55,6 @@ export default class FilterExercises extends Component {
             </FilterTag>
           ))}
         </div>
-        <AutoComplete
-          dataSource={[...new Set(this.props.exercises)].map(e => (
-            <AutoComplete.Option key={e.exercise_name} text={e.exercise_name}>
-              {e.exercise_name}
-            </AutoComplete.Option>
-          ))}
-          style={{ width: 300, marginTop: "1rem" }}
-          onChange={exercise_name => {this.props.searchExercise(exercise_name)}}
-          optionLabelProp="text"
-        >
-          <Input
-            suffix={<Icon type="search" className="certain-category-icon" />}
-            placeholder="Search Exercises"
-          />
-        </AutoComplete>
       </div>
     );
   }

--- a/workout-tracker/src/views/customWorkout/FilterExercises.js
+++ b/workout-tracker/src/views/customWorkout/FilterExercises.js
@@ -62,8 +62,8 @@ export default class FilterExercises extends Component {
               {e.exercise_name}
             </AutoComplete.Option>
           ))}
-          style={{ width: 300 }}
-          onChange={exercise_name => this.props.searchExercise(exercise_name)}
+          style={{ width: 300, marginTop: "1rem" }}
+          onChange={exercise_name => {this.props.searchExercise(exercise_name)}}
           optionLabelProp="text"
         >
           <Input

--- a/workout-tracker/src/views/customWorkout/SelectedExercises.js
+++ b/workout-tracker/src/views/customWorkout/SelectedExercises.js
@@ -17,7 +17,7 @@ export default class SelectedExercises extends Component {
           itemLayout="vertical"
           renderItem={item => (
             <List.Item
-              extra={
+              extra={!this.props.saveExercise &&
                 <Button
                   size="small"
                   type="danger"

--- a/workout-tracker/src/views/customWorkout/SetsForm.js
+++ b/workout-tracker/src/views/customWorkout/SetsForm.js
@@ -65,7 +65,7 @@ class SetsForm extends Component {
           <Divider />
           {keys.map(k => (<>
             <FormItemsContainer key={`${e.id}${k}`} style={{ textAlign: "center" }}>
-              <StyledFormItem key={k + "2" + e}>
+              <Form.Item key={k + "2" + e}>
                 {getFieldDecorator(`${e.id}type[${k}]`, {
                   initialValue: "reps"
                 })(
@@ -74,8 +74,8 @@ class SetsForm extends Component {
                     <Radio.Button value="duration">Duration</Radio.Button>
                   </Radio.Group>
                 )}
-              </StyledFormItem>
-              <StyledFormItem
+              </Form.Item>
+              <Form.Item
                 label={
                   getFieldValue(`${e.id}type[${k}]`) === "reps"
                     ? "Reps"
@@ -95,8 +95,8 @@ class SetsForm extends Component {
                     }
                   ]
                 })(<InputNumber min={1} max={200} />)}
-              </StyledFormItem>
-              <StyledFormItem label="Weight (kg)" required={false} key={k + "1"}>
+              </Form.Item>
+              <Form.Item label="Weight (kg)" required={false} key={k + "1"}>
                 {getFieldDecorator(`${e.id}weight[${k}]`, {
                   validateTrigger: ["onChange", "onBlur"],
                   rules: [
@@ -108,7 +108,7 @@ class SetsForm extends Component {
                     }
                   ]
                 })(<InputNumber min={1} max={200} />)}
-              </StyledFormItem>
+              </Form.Item>
               {keys.length > 0 ? (
                 <Icon
                   className="dynamic-delete-button"

--- a/workout-tracker/src/views/customWorkout/SetsForm.js
+++ b/workout-tracker/src/views/customWorkout/SetsForm.js
@@ -1,11 +1,11 @@
 import React, { Component } from "react";
-import { Form, Radio, InputNumber, Icon, Button } from "antd";
+import { Form, Radio, InputNumber, Icon, Button, Card } from "antd";
 
 class SetsForm extends Component {
   remove = (e, k) => {
     const { form } = this.props;
     const keys = form.getFieldValue(`${e}keys`);
-    if (keys.length === 1) {
+    if (keys.length === 0) {
       return;
     }
     form.setFieldsValue({
@@ -60,7 +60,7 @@ class SetsForm extends Component {
       getFieldDecorator(`${e.id}keys`, { initialValue: [] });
       const keys = getFieldValue(`${e.id}keys`);
       return (
-        <div key={e.id}>
+        <Card key={e.id}>
           <h3>{e.exercise_name}</h3>
           {keys.map(k => (
             <div key={`${e.id}${k}`}>
@@ -108,7 +108,7 @@ class SetsForm extends Component {
                   ]
                 })(<InputNumber min={1} max={200} />)}
               </Form.Item>
-              {keys.length > 1 ? (
+              {keys.length > 0 ? (
                 <Icon
                   className="dynamic-delete-button"
                   type="minus-circle-o"
@@ -126,7 +126,7 @@ class SetsForm extends Component {
               Add field
             </Button>
           </Form.Item>
-        </div>
+        </Card>
       );
     });
 
@@ -135,8 +135,8 @@ class SetsForm extends Component {
         <Form layout="inline" onSubmit={this.handleSubmit}>
           {exerciseSet}
           <Form.Item>
-    <Button type="primary" htmlType="submit" loading={false}>           {/* loading needs to be changed to loading={this.props.loading} */}
-              {this.props.loading ? "Creating Workout..." : "Create Workout"}
+            <Button style={{ margin: "1rem" }} type="primary" size="large" htmlType="submit" loading={this.props.loading}>
+              {this.props.loading ? " Creating Workout..." : "Create Workout"}
             </Button>
           </Form.Item>
         </Form>

--- a/workout-tracker/src/views/customWorkout/SetsForm.js
+++ b/workout-tracker/src/views/customWorkout/SetsForm.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
-import { Form, Radio, InputNumber, Icon, Button, Card } from "antd";
+import { Form, Radio, InputNumber, Icon, Button, Card, Divider, Alert } from "antd";
+import styled from "styled-components";
 
 class SetsForm extends Component {
   remove = (e, k) => {
@@ -35,7 +36,6 @@ class SetsForm extends Component {
           const type = values[`${ex.id}type`];
           keys.forEach((element, index) => {
             const newObject = {};
-            console.log(type[element]);
             if (type[element] === "reps") newObject["reps"] = reps[element] ? reps[element] : null;
             else newObject["duration"] = reps[element]? `${reps[element]} seconds`: null;
             newObject["weights"] = weight[element] ? weight[element]: null;
@@ -62,9 +62,10 @@ class SetsForm extends Component {
       return (
         <Card key={e.id}>
           <h3>{e.exercise_name}</h3>
-          {keys.map(k => (
-            <div key={`${e.id}${k}`}>
-              <Form.Item key={k + "2" + e}>
+          <Divider />
+          {keys.map(k => (<>
+            <FormItemsContainer key={`${e.id}${k}`} style={{ textAlign: "center" }}>
+              <StyledFormItem key={k + "2" + e}>
                 {getFieldDecorator(`${e.id}type[${k}]`, {
                   initialValue: "reps"
                 })(
@@ -73,8 +74,8 @@ class SetsForm extends Component {
                     <Radio.Button value="duration">Duration</Radio.Button>
                   </Radio.Group>
                 )}
-              </Form.Item>
-              <Form.Item
+              </StyledFormItem>
+              <StyledFormItem
                 label={
                   getFieldValue(`${e.id}type[${k}]`) === "reps"
                     ? "Reps"
@@ -94,8 +95,8 @@ class SetsForm extends Component {
                     }
                   ]
                 })(<InputNumber min={1} max={200} />)}
-              </Form.Item>
-              <Form.Item label="Weight (kg)" required={false} key={k + "1"}>
+              </StyledFormItem>
+              <StyledFormItem label="Weight (kg)" required={false} key={k + "1"}>
                 {getFieldDecorator(`${e.id}weight[${k}]`, {
                   validateTrigger: ["onChange", "onBlur"],
                   rules: [
@@ -107,15 +108,18 @@ class SetsForm extends Component {
                     }
                   ]
                 })(<InputNumber min={1} max={200} />)}
-              </Form.Item>
+              </StyledFormItem>
               {keys.length > 0 ? (
                 <Icon
                   className="dynamic-delete-button"
                   type="minus-circle-o"
+                  style={{ fontSize: "2rem" }}
                   onClick={() => this.remove(e.id, k)}
                 />
               ) : null}
-            </div>
+            </FormItemsContainer>
+            <Divider />
+            </>
           ))}
           <Form.Item>
             <Button
@@ -129,7 +133,6 @@ class SetsForm extends Component {
         </Card>
       );
     });
-
     return (
       <div>
         <Form layout="inline" onSubmit={this.handleSubmit}>
@@ -140,9 +143,51 @@ class SetsForm extends Component {
             </Button>
           </Form.Item>
         </Form>
+        {this.props.error && this.props.error.exercises && <Alert style={{ display: "inline-block"}}
+          message="Error"
+          description={this.props.error.exercises}
+          type="error"
+          showIcon
+        />} <br />
+        {this.props.error && this.props.error.workout_name && <Alert style={{ display: "inline-block"}}
+          message="Error"
+          description={this.props.error.workout_name}
+          type="error"
+          showIcon
+        />} <br />
+        {this.props.error && this.props.error.workout_description && <Alert style={{ display: "inline-block"}}
+          message="Error"
+          description={this.props.error.workout_description}
+          type="error"
+          showIcon
+        />} <br />
+        {this.props.error && 
+          !this.props.error.exercises && 
+          !this.props.error.workout_name && 
+          !this.props.error.workout_description &&
+          this.props.error.code &&
+         <Alert style={{ display: "inline-block"}}
+          message="Error"
+          description="Workout name already exists"
+          type="error"
+          showIcon
+        />}
       </div>
     );
   }
 }
 
 export default Form.create({ name: "sets-form" })(SetsForm);
+
+const FormItemsContainer = styled.div`
+
+  @media screen and (max-width: 760px) {
+    display: flex;
+    flex-direction: column;
+
+    .ant-form-item-label {
+      text-align: center;
+    }
+  }
+
+`

--- a/workout-tracker/src/views/customWorkout/SideBar.js
+++ b/workout-tracker/src/views/customWorkout/SideBar.js
@@ -42,6 +42,7 @@ class SideBar extends Component {
           <SelectedExercises
             remove={this.props.removeFromSelectedExercises}
             exercises={this.props.selectedExercises}
+            saveExercise={this.props.saveExercise}
           />
         </div>
       </div>

--- a/workout-tracker/src/views/customWorkout/UpdateWorkoutDetails.js
+++ b/workout-tracker/src/views/customWorkout/UpdateWorkoutDetails.js
@@ -9,7 +9,7 @@ const UpdateWorkoutDetails = Form.create({ name: "update_workout" })(
       const { getFieldDecorator } = form;
       return (
         <Form style={{ marginTop: '1rem'}} layout="inline">
-          <Form.Item label="Workout Name" >
+          <Form.Item label="Name" >
             {getFieldDecorator("workout_name", {
               initialValue: `${this.props.name || ''}`,
               rules: [


### PR DESCRIPTION
##  What does this PR do
This PR makes the custom workout page mobile responsive and improves on UX

##  Description of task to be completed
- remove `delete icon` from selected exercises when adding sets
- edit `workout_name` label to make it more concise
- sort exercises in alphabetical order and more whitespace around each exercise card
- add top margin to search bar
- Add margin and border to differentiate exercises
- disable exercise button if no exercise is added
- remove search from filter component
- add media query for responsiveness
- rearrange components for mobile responsiveness
- Add page header to mobile view
- hide mobile menu icons on the desktop
- Add confirm exit box to customise workout page
- handle error and make sets form responsive
- make create workout button fixed
- check if workout name exists
- make exercise card responsive
- remove custom style on `Form.Item`

##  How should this manually be tested
checkout `modify-custom-workouts-page`
yarn install
yarn start

##  What are the relevant Trello board stories
[Mobile view for Workout Builder](https://trello.com/c/nJnOJVP7/242-mobile-view-for-workout-builder#)

##  Screenshots (If appropriate)
![Capture+_2019-09-27-07-07-55](https://user-images.githubusercontent.com/12853775/65747404-42943b00-e0f9-11e9-9782-c183a08f1872.png)
![Capture+_2019-09-27-07-10-12](https://user-images.githubusercontent.com/12853775/65747417-4aec7600-e0f9-11e9-92f4-605795f479bd.png)
![Capture+_2019-09-27-07-10-18](https://user-images.githubusercontent.com/12853775/65747424-4f189380-e0f9-11e9-97d6-add43cd71549.png)
![Capture+_2019-09-27-07-10-41](https://user-images.githubusercontent.com/12853775/65747434-53dd4780-e0f9-11e9-9afa-9dba409940ec.png)
![Capture+_2019-09-27-07-10-49](https://user-images.githubusercontent.com/12853775/65747442-58096500-e0f9-11e9-9ab9-8f9a5f15c9b9.png)
![Capture+_2019-09-27-07-11-11](https://user-images.githubusercontent.com/12853775/65747458-5d66af80-e0f9-11e9-865e-3a5a8b67aa80.png)
![Capture+_2019-09-27-07-11-17](https://user-images.githubusercontent.com/12853775/65747463-6192cd00-e0f9-11e9-9a8e-4b6cb4afcc72.png)
![Capture+_2019-09-27-07-11-24](https://user-images.githubusercontent.com/12853775/65747475-66578100-e0f9-11e9-9ebd-7bd42516f1e1.png)
![Capture+_2019-09-27-07-12-35](https://user-images.githubusercontent.com/12853775/65747487-6fe0e900-e0f9-11e9-9b1a-145a9491bf83.png)
![Capture+_2019-09-27-07-12-42](https://user-images.githubusercontent.com/12853775/65747498-7b341480-e0f9-11e9-9440-b4ccf69e0d17.png)
![Capture+_2019-09-27-07-12-48](https://user-images.githubusercontent.com/12853775/65747502-7ec79b80-e0f9-11e9-8df5-aaefb4eaf038.png)
![Capture+_2019-09-27-07-13-01](https://user-images.githubusercontent.com/12853775/65747506-838c4f80-e0f9-11e9-90f6-3d69f71d78dc.png)
![Capture+_2019-09-27-07-13-12](https://user-images.githubusercontent.com/12853775/65747509-86874000-e0f9-11e9-9918-46f0ac5f56ec.png)

